### PR TITLE
Also block 'Do not merge' PRs

### DIFF
--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,7 +2,7 @@ module.exports = handlePullRequestChange
 
 async function handlePullRequestChange (robot, context) {
   const title = context.payload.pull_request.title
-  const isWip = /\bwip\b/i.test(title)
+  const isWip = /\b(wip|do not merge)\b/i.test(title)
   const status = isWip ? 'pending' : 'success'
 
   console.log(`Updating PR "${title}" (${context.payload.pull_request.html_url}): ${status}`)


### PR DESCRIPTION
PRs are regularly marked as "Do not merge" or "[DO NOT MERGE]" while they are worked on. Allow WIP bot to block the merge of these PRs too.

Fixes #26