### PR TITLE
Support WIP labels

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,9 +10,10 @@
 
 - Install the app on your GitHub Repositories: [github.com/apps/wip](https://github.com/apps/wip)
 - When creating a pull request that you don’t want to be merged, simply add the
-  word "wip" or "do not merge" (not case-sensitive) somewhere in the pull request title
+  word "wip" or "do not merge" (not case-sensitive) somewhere in the pull request title,
+  or add a label containing "wip"
 - The WIP bot will set/update the status of the pull request depending on the
-  pull requests title.
+  pull request's title or labels.
 
 ## Local setup
 

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,7 +2,7 @@ module.exports = handlePullRequestChange
 
 async function handlePullRequestChange (context) {
   const {title, html_url: htmlUrl, head} = context.payload.pull_request
-  const isWip = containsWIP(title) || await commitsContainWIP(context) || labelsContainWIP(context)
+  const isWip = containsWIP(title) || await commitsContainWIP(context) || await labelsContainWIP(context)
   const status = isWip ? 'pending' : 'success'
 
   console.log(`Updating PR "${title}" (${htmlUrl}): ${status}`)

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -2,7 +2,7 @@ module.exports = handlePullRequestChange
 
 async function handlePullRequestChange (context) {
   const {title, html_url: htmlUrl, head} = context.payload.pull_request
-  const isWip = containsWIP(title) || await commitsContainWIP(context)
+  const isWip = containsWIP(title) || await commitsContainWIP(context) || labelsContainWIP(context)
   const status = isWip ? 'pending' : 'success'
 
   console.log(`Updating PR "${title}" (${htmlUrl}): ${status}`)
@@ -22,6 +22,14 @@ async function commitsContainWIP (context) {
   }))
 
   return commits.data.map(element => element.commit.message).some(containsWIP)
+}
+
+async function labelsContainWIP (context) {
+  const labels = await context.github.issues.getIssueLabels(context.repo({
+    number: context.payload.pull_request.number
+  }))
+
+  return labels.data.map(label => label.name).some(containsWIP)
 }
 
 function containsWIP (string) {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,12 @@
     "semantic-release": "semantic-release"
   },
   "standard": {
-    "globals": [ "jest", "it", "expect", "describe" ]
+    "globals": [
+      "jest",
+      "it",
+      "expect",
+      "describe"
+    ]
   },
   "repository": {
     "type": "git",

--- a/test/unit/lib/handle-pull-request-change.test.js
+++ b/test/unit/lib/handle-pull-request-change.test.js
@@ -24,6 +24,26 @@ describe('handlePullRequestChange', () => {
     }
   }
 
+  const createMockCommitContext = commitMessage => {
+    const context = createMockContext('Example PR title')
+
+    context.github.pullRequests.getCommits = jest.fn().mockReturnValue({
+      data: [{ commit: { message: commitMessage } }]
+    })
+
+    return context
+  }
+
+  const createMockLabelContext = labelName => {
+    const context = createMockContext('Example PR title')
+
+    context.github.issues.getIssueLabels = jest.fn().mockReturnValue({
+      data: [{ name: labelName }]
+    })
+
+    return context
+  }
+
   const pendingStatusObject = {
     context: 'WIP',
     description: 'work in progress – do not merge!',
@@ -63,6 +83,48 @@ describe('handlePullRequestChange', () => {
 
   it('creates success status if PR title does NOT contain `wip`', async () => {
     const context = createMockContext('[xxx] foo bar commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(successStatusObject)
+  })
+
+  it('creates pending status if a commit message contains `wip`', async () => {
+    const context = createMockCommitContext('[wip] foo bar commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates pending status if a commit message contains `do not merge`', async () => {
+    const context = createMockCommitContext('my DO NOT MERGE commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates success status if a commit message does not contain `wip` or `do not merge`', async () => {
+    const context = createMockCommitContext('my commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(successStatusObject)
+  })
+
+  it('creates pending status if a label contains `wip`', async () => {
+    const context = createMockLabelContext('WIP')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates pending status if a label contains `do not merge`', async () => {
+    const context = createMockLabelContext('do not merge')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates success status if a label does not contain `wip` or `do not merge`', async () => {
+    const context = createMockLabelContext('bug')
     await handlePullRequestChange(context)
 
     expect(context.repo).lastCalledWith(successStatusObject)

--- a/test/unit/lib/handle-pull-request-change.test.js
+++ b/test/unit/lib/handle-pull-request-change.test.js
@@ -16,6 +16,9 @@ describe('handlePullRequestChange', () => {
         },
         pullRequests: {
           getCommits: jest.fn().mockReturnValue({ data: [] })
+        },
+        issues: {
+          getIssueLabels: jest.fn().mockReturnValue({ data: [] })
         }
       }
     }


### PR DESCRIPTION
I'm a fan of marking a pull request as a work in progress using a [WIP] label, so this pull request adds support for labels whose names contain "wip" or "do not merge" just like commit messages or PR titles.