### PR TITLE
Block merging when commits should be autosquashed

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,12 +9,17 @@
 ## Usage
 
 1. Install the app on your GitHub Repositories: [github.com/apps/wip](https://github.com/apps/wip)
-2. The WIP bot sets status of the request title to pending if it finds  "wip", "work in progress" or "do not merge" (not case-sensitive) in
+2. If the WIP bot finds "wip", "work in progress" or "do not merge" (not case-sensitive) in
    1. The pull request title
    2. One of the pull request labels
    3. One of the pull request commit messages
-3. If it doesn’t find the words anywhere, it will set status to success
 
+   it sets status of the request title to pending
+3. If it finds "fixup!" or "squash!" (case-sensitive) at the beginning of
+   the commit message (indicating that the commit [should be squashed into
+   another commit](https://git-scm.com/docs/git-rebase#git-rebase---autostash))
+   it sets status of the request title to pending
+4. If it doesn’t find the words anywhere, it will set status to success
 ## Local setup
 
 - Setup repository

--- a/lib/handle-pull-request-change.js
+++ b/lib/handle-pull-request-change.js
@@ -23,7 +23,7 @@ async function commitsContainWIP (context) {
     number: context.payload.pull_request.number
   }))
 
-  return commits.data.map(element => element.commit.message).some(containsWIP)
+  return commits.data.map(element => element.commit.message).some(or(containsWIP, isAutoSquash))
 }
 
 async function labelsContainWIP (context) {
@@ -36,4 +36,14 @@ async function labelsContainWIP (context) {
 
 function containsWIP (string) {
   return /\b(wip|do not merge|work in progress)\b/i.test(string)
+}
+
+function isAutoSquash (string) {
+  return /^(fixup!|squash!)/.test(string)
+}
+
+function or (predicate1, predicate2) {
+  return function (subject) {
+    return predicate1(subject) || predicate2(subject)
+  }
 }

--- a/test/unit/lib/handle-pull-request-change.test.js
+++ b/test/unit/lib/handle-pull-request-change.test.js
@@ -105,8 +105,22 @@ describe('handlePullRequestChange', () => {
     expect(context.repo).lastCalledWith(pendingStatusObject)
   })
 
-  it('creates success status if a commit message does not contain `wip` or `do not merge`', async () => {
-    const context = createMockCommitContext('my commit message')
+  it('creates pending status if a commit message begins with `fixup!`', async () => {
+    const context = createMockCommitContext('fixup! my commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates pending status if a commit message begins with `squash!`', async () => {
+    const context = createMockCommitContext('squash! my commit message')
+    await handlePullRequestChange(context)
+
+    expect(context.repo).lastCalledWith(pendingStatusObject)
+  })
+
+  it('creates success status if a commit message does not contain `wip` or `do not merge` or begin with `fixup!` or `squash!`', async () => {
+    const context = createMockCommitContext('my commit fixup! squash! message')
     await handlePullRequestChange(context)
 
     expect(context.repo).lastCalledWith(successStatusObject)


### PR DESCRIPTION
Fixes #55.

Sets status of pull requests containing commits whose messages
begin with "fixup!" or "squash!" to pending.